### PR TITLE
Ensure Render SPA rewrites deploy with build output

### DIFF
--- a/public/static.json
+++ b/public/static.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/.*",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- move static.json into the public/ folder so it is copied into dist during the Vite build
- ensure Render's static hosting sees the SPA rewrite rules and serves index.html for nested routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87023c464832da87592345589f9ab