### PR TITLE
Add SPA fallback configuration and routing test

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,19 @@ docker-compose -f docker-compose.prod.yml up
 
 ## Deployment notes for SPA routing
 
-If you deploy the frontend as a static Single Page App (SPA) you must ensure unknown routes are rewritten to `index.html` so client-side routing (React Router) works. This repo includes `public/_redirects` for Netlify/Render and `render.yaml` uses `staticPublishPath: dist` for correct behavior on Render. Without these, direct navigation to routes like `/login` or `/dashboard` returns 404 from the static file server.
+If you deploy the frontend as a static Single Page App (SPA) you must ensure unknown routes are rewritten to `index.html` so client-side routing (React Router) works. This repo includes:
+
+- `public/_redirects` for Netlify and Render
+- `public/static.json` for Render
+- `public/.htaccess` for Apache/cPanel hosting
+- `static.json` in the project root for Render static sites
+
+Without these, direct navigation to routes like `/login` or `/dashboard` returns 404 from the static file server.
+
+You can verify the SPA fallback locally with:
+
+```bash
+npm run test:spa
+```
+
+This command builds the project, serves the production bundle with history fallback enabled, and asserts that `/`, `/login`, and `/dashboard` all return the SPA shell instead of a 404.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:production": "npm install && npm run build",
     "build:netlify": "npm install && npm run build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:spa": "node scripts/test-spa-routing.mjs"
   },
   "dependencies": {
     "axios": "^1.12.2",
@@ -35,7 +36,6 @@
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
     "postcss": "^8.4.35",
-    "serve": "^14.2.5",
     "serve": "^14.2.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.html$ - [L]
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^ /index.html [L]

--- a/scripts/test-spa-routing.mjs
+++ b/scripts/test-spa-routing.mjs
@@ -1,0 +1,81 @@
+import { spawn } from 'node:child_process';
+import { setTimeout as wait } from 'node:timers/promises';
+import { once } from 'node:events';
+
+const abortController = new AbortController();
+
+async function build() {
+  console.log('Building production bundle...');
+  const buildProcess = spawn('npm', ['run', 'build'], { stdio: 'inherit', signal: abortController.signal });
+  const [code] = await once(buildProcess, 'exit');
+  if (code !== 0) {
+    throw new Error(`Build failed with exit code ${code}`);
+  }
+}
+
+async function startPreviewServer() {
+  console.log('Starting static server on http://localhost:4173 ...');
+  const server = spawn('npx', ['serve', 'dist', '-l', '4173', '--single'], { stdio: 'pipe', signal: abortController.signal });
+
+  let serverReady = false;
+  server.stdout.on('data', (data) => {
+    const text = data.toString();
+    process.stdout.write(text);
+    if (text.includes('Accepting connections')) {
+      serverReady = true;
+    }
+  });
+  server.stderr.on('data', (data) => process.stderr.write(data.toString()));
+
+  for (let i = 0; i < 20; i += 1) {
+    if (serverReady) break;
+    await wait(250);
+  }
+
+  if (!serverReady) {
+    server.kill();
+    throw new Error('Static server did not start in time');
+  }
+
+  return server;
+}
+
+async function assertRoute(route) {
+  const url = `http://localhost:4173${route}`;
+  const response = await fetch(url, { redirect: 'manual' });
+  if (response.status !== 200) {
+    throw new Error(`Expected 200 for ${route}, received ${response.status}`);
+  }
+  const text = await response.text();
+  if (!text.includes('<div id="root"></div>')) {
+    throw new Error(`Response for ${route} does not contain the SPA root element.`);
+  }
+  console.log(`✔ Route ${route} serves index.html`);
+}
+
+async function main() {
+  await build();
+  const server = await startPreviewServer();
+
+  try {
+    await assertRoute('/');
+    await assertRoute('/login');
+    await assertRoute('/dashboard');
+  } finally {
+    server.kill('SIGTERM');
+    await wait(250);
+    if (!server.killed) {
+      server.kill('SIGKILL');
+    }
+    server.stdout?.destroy();
+    server.stderr?.destroy();
+  }
+
+  console.log('SPA routing test finished successfully.');
+}
+
+main().catch((error) => {
+  abortController.abort();
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add Apache-compatible .htaccess rewrite rules so direct route loads the SPA
- document the available SPA rewrites and new verification workflow in the README
- add an automated script and npm script to build the app, serve the bundle, and assert key routes return index.html

## Testing
- npm run test:spa

------
https://chatgpt.com/codex/tasks/task_e_68d8769416ac832da36482c311f8a5a5